### PR TITLE
Implemented mouse/controller input, tracef!(), added DrawIndex arg to drawing primitives

### DIFF
--- a/wasm4/Cargo.toml
+++ b/wasm4/Cargo.toml
@@ -14,9 +14,11 @@ edition = "2021"
 [features]
 std = []
 include-sprites = ["dep:wasm4-impl"]
+tracef = ["dep:format_no_std"]
 
 [dependencies]
 bitflags = "1.3.2"
+format_no_std = { version = "1.2.0", optional = true }
 
 [dependencies.wasm4-sys]
 path = "../wasm4-sys"

--- a/wasm4/src/control.rs
+++ b/wasm4/src/control.rs
@@ -4,7 +4,7 @@ use wasm4_sys::*;
 
 pub struct Controls {
     pub mouse: Mouse,
-    pub gamepad: Gamepad,
+    pub gamepads: [Gamepad; 4],
 }
 
 pub struct Mouse(PhantomData<*const ()>);
@@ -34,15 +34,13 @@ pub struct MouseState {
     pub buttons: [bool; 3],
 }
 
-pub struct Gamepad(PhantomData<*const ()>);
+pub struct Gamepad(*const u8);
 impl Gamepad {
-    pub(crate) unsafe fn new_() -> Self {
-        Self(PhantomData)
+    pub(crate) unsafe fn new_(gamepad: *const u8) -> Self {
+        Self(gamepad)
     }
-    pub fn state(&self, id: usize) -> GamepadState {
-        let gamepad = unsafe {
-            [*GAMEPAD1, *GAMEPAD2, *GAMEPAD3, *GAMEPAD4]
-        }[id];
+    pub fn state(&self) -> GamepadState {
+        let gamepad = unsafe { *self.0 };
 
         GamepadState {
             buttons: [

--- a/wasm4/src/control.rs
+++ b/wasm4/src/control.rs
@@ -1,0 +1,83 @@
+use core::marker::PhantomData;
+
+use wasm4_sys::*;
+
+pub struct Controls {
+    pub mouse: Mouse,
+    pub gamepad: Gamepad,
+}
+
+pub struct Mouse(PhantomData<*const ()>);
+impl Mouse {
+    pub(crate) unsafe fn new_() -> Self {
+        Self(PhantomData)
+    }
+    pub fn state(&self) -> MouseState {
+        let buttons = unsafe { *MOUSE_BUTTONS };
+        let x = unsafe { *MOUSE_X };
+        let y = unsafe { *MOUSE_Y };
+
+        MouseState {
+            x,
+            y,
+            buttons: [
+                buttons & MOUSE_LEFT != 0,
+                buttons & MOUSE_RIGHT != 0,
+                buttons & MOUSE_MIDDLE != 0,
+            ]
+        }
+    }
+}
+pub struct MouseState {
+    pub x: i16,
+    pub y: i16,
+    pub buttons: [bool; 3],
+}
+
+pub struct Gamepad(PhantomData<*const ()>);
+impl Gamepad {
+    pub(crate) unsafe fn new_() -> Self {
+        Self(PhantomData)
+    }
+    pub fn state(&self, id: usize) -> GamepadState {
+        let gamepad = unsafe {
+            [*GAMEPAD1, *GAMEPAD2, *GAMEPAD3, *GAMEPAD4]
+        }[id];
+
+        GamepadState {
+            buttons: [
+                gamepad & BUTTON_1 != 0,
+                gamepad & BUTTON_2 != 0,
+            ],
+            dpad: Directions {
+                up: gamepad & BUTTON_UP != 0,
+                down: gamepad & BUTTON_DOWN != 0,
+                left: gamepad & BUTTON_LEFT != 0,
+                right: gamepad & BUTTON_RIGHT != 0,
+            }
+        }
+    }
+}
+pub struct GamepadState {
+    pub buttons: [bool; 2],
+    pub dpad: Directions,
+}
+impl GamepadState {
+    pub fn clean(self) -> Self {
+        GamepadState {
+            buttons: self.buttons,
+            dpad: Directions { 
+                up: if self.dpad.up ^ self.dpad.down { self.dpad.up } else { false },
+                down: if self.dpad.up ^ self.dpad.down { self.dpad.down } else { false },
+                left: if self.dpad.left ^ self.dpad.right { self.dpad.left } else { false },
+                right: if self.dpad.left ^ self.dpad.right { self.dpad.right } else { false },
+            },
+        }
+    }
+}
+pub struct Directions {
+    up: bool,
+    down: bool,
+    left: bool,
+    right: bool,
+}

--- a/wasm4/src/control.rs
+++ b/wasm4/src/control.rs
@@ -28,11 +28,13 @@ impl Mouse {
         }
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MouseState {
     pub x: i16,
     pub y: i16,
     pub buttons: MouseButtons,
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MouseButtons {
     pub left: bool,
     pub right: bool,
@@ -61,6 +63,7 @@ impl Gamepad {
         }
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GamepadState {
     pub buttons: [bool; 2],
     pub dpad: Directions,
@@ -78,6 +81,7 @@ impl GamepadState {
         }
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Directions {
     up: bool,
     down: bool,

--- a/wasm4/src/control.rs
+++ b/wasm4/src/control.rs
@@ -20,18 +20,23 @@ impl Mouse {
         MouseState {
             x,
             y,
-            buttons: [
-                buttons & MOUSE_LEFT != 0,
-                buttons & MOUSE_RIGHT != 0,
-                buttons & MOUSE_MIDDLE != 0,
-            ]
+            buttons: MouseButtons {
+                left: buttons & MOUSE_LEFT != 0,
+                right: buttons & MOUSE_RIGHT != 0,
+                middle: buttons & MOUSE_MIDDLE != 0,
+            }
         }
     }
 }
 pub struct MouseState {
     pub x: i16,
     pub y: i16,
-    pub buttons: [bool; 3],
+    pub buttons: MouseButtons,
+}
+pub struct MouseButtons {
+    pub left: bool,
+    pub right: bool,
+    pub middle: bool,
 }
 
 pub struct Gamepad(*const u8);

--- a/wasm4/src/control.rs
+++ b/wasm4/src/control.rs
@@ -70,10 +70,10 @@ impl GamepadState {
         GamepadState {
             buttons: self.buttons,
             dpad: Directions { 
-                up: if self.dpad.up ^ self.dpad.down { self.dpad.up } else { false },
-                down: if self.dpad.up ^ self.dpad.down { self.dpad.down } else { false },
-                left: if self.dpad.left ^ self.dpad.right { self.dpad.left } else { false },
-                right: if self.dpad.left ^ self.dpad.right { self.dpad.right } else { false },
+                up: self.dpad.up && !self.dpad.down,
+                down: self.dpad.down && !self.dpad.up,
+                left: self.dpad.left && !self.dpad.right,
+                right: self.dpad.right && !self.dpad.left,
             },
         }
     }

--- a/wasm4/src/draw.rs
+++ b/wasm4/src/draw.rs
@@ -31,28 +31,76 @@ impl Framebuffer {
         unsafe { &*(wasm4_sys::FRAMEBUFFER.cast::<[Cell<u8>; 6400]>()) }
     }
 
-    pub fn line(&self, start: [i32; 2], end: [i32; 2]) {
-        unsafe { wasm4_sys::line(start[0], start[1], end[0], end[1]) }
+    pub fn line(&self, start: [i32; 2], end: [i32; 2], color: DrawIndex) {
+        unsafe {
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                color,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::line(start[0], start[1], end[0], end[1]);
+        }
     }
 
-    pub fn hline(&self, start: [i32; 2], len: u32) {
-        unsafe { wasm4_sys::hline(start[0], start[1], len) }
+    pub fn hline(&self, start: [i32; 2], len: u32, color: DrawIndex) {
+        unsafe {
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                color,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::hline(start[0], start[1], len);
+        }
     }
 
-    pub fn vline(&self, start: [i32; 2], len: u32) {
-        unsafe { wasm4_sys::vline(start[0], start[1], len) }
+    pub fn vline(&self, start: [i32; 2], len: u32, color: DrawIndex) {
+        unsafe {
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                color,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::vline(start[0], start[1], len);
+        }
     }
 
-    pub fn oval(&self, start: [i32; 2], shape: [u32; 2]) {
-        unsafe { wasm4_sys::oval(start[0], start[1], shape[0], shape[1]) }
+    pub fn oval(&self, start: [i32; 2], shape: [u32; 2], fill: DrawIndex, outline: DrawIndex) {
+        unsafe {
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                fill,
+                outline,
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::oval(start[0], start[1], shape[0], shape[1]);
+        }
     }
 
-    pub fn rect(&self, start: [i32; 2], shape: [u32; 2]) {
-        unsafe { wasm4_sys::rect(start[0], start[1], shape[0], shape[1]) }
+    pub fn rect(&self, start: [i32; 2], shape: [u32; 2], fill: DrawIndex, outline: DrawIndex) {
+        unsafe {
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                fill,
+                outline,
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::rect(start[0], start[1], shape[0], shape[1]);
+        }
     }
 
-    pub fn text(&self, text: &str, start: [i32; 2]) {
-        unsafe { wasm4_sys::textUtf8(text.as_ptr(), text.len(), start[0], start[1]) }
+    pub fn text(&self, text: &str, start: [i32; 2], fg: DrawIndex, bg: DrawIndex) {
+        unsafe { 
+            wasm4_sys::DRAW_COLORS.write(DrawIndices::from_array([
+                fg,
+                bg,
+                Default::default(),
+                Default::default(),
+            ]).into());
+            wasm4_sys::textUtf8(text.as_ptr(), text.len(), start[0], start[1]);
+        }
     }
 
     pub fn blit(&self, sprite: &impl Blit, start: [i32; 2], transform: BlitTransform) {

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -2,7 +2,7 @@
 macro_rules! tracef {
     ($($arg:tt)*) => {{
         $crate::trace($crate::format::format_no_std::show(
-            *$crate::format::BUF_SLICE,
+            *($crate::format::BUF_SLICE.expect("Logger not initialized")),
             ::core::format_args!($($arg)*)
         ).unwrap());
     }};

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -10,12 +10,12 @@ macro_rules! tracef {
 
 pub use format_no_std;
 
-static mut BUF_SLICE: Option<&str> = None;
+static mut BUF_SLICE: Option<&mut [u8]> = None;
 
 pub struct Log;
 impl Log {
     pub(crate) fn new_() -> Self { Log }
-    pub fn init(self, buf: &'static mut str) {
+    pub fn init(self, buf: &'static mut [u8]) {
         unsafe { BUF_SLICE = Some(buf) };
     }
 }

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -1,12 +1,14 @@
 #[macro_export]
 macro_rules! tracef {
     ($($arg:tt)*) => {{
-        $crate::trace(::format_no_std::show(
-            *BUF_SLICE,
+        $crate::trace($crate::format::format_no_std::show(
+            *$crate::format::BUF_SLICE,
             ::core::format_args!($($arg)*)
         ).unwrap());
     }};
 }
+
+pub use format_no_std;
 
 static mut BUF_SLICE: Option<&str> = None;
 

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -1,0 +1,20 @@
+#[macro_export]
+macro_rules! tracef {
+    ($($arg:tt)*) => {{
+        $crate::trace(::format_no_std::show(
+            *BUF_SLICE,
+            ::core::format_args!($($arg)*)
+        ).unwrap());
+    }};
+}
+
+static mut BUF_SLICE: Option<&str> = None;
+
+pub struct Log;
+impl Log {
+    pub(crate) fn new_() -> Self { Log }
+    pub fn init(self, buf: &'static mut str) {
+        unsafe { BUF_SLICE = Some(buf) };
+    }
+}
+

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -2,7 +2,7 @@
 macro_rules! tracef {
     ($($arg:tt)*) => {{
         $crate::trace($crate::format::format_no_std::show(
-            *($crate::format::BUF_SLICE.expect("Logger not initialized")),
+            $crate::format::BUF_SLICE.expect("Logger not initialized"),
             ::core::format_args!($($arg)*)
         ).unwrap());
     }};

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -2,7 +2,10 @@
 macro_rules! tracef {
     ($($arg:tt)*) => {{
         $crate::trace($crate::format::format_no_std::show(
-            $crate::format::BUF_SLICE.expect("Logger not initialized"),
+            unsafe { match &mut $crate::format::BUF_SLICE {
+                Some(slice) => slice,
+                None => panic!("Logger not initialized"),
+            }},
             ::core::format_args!($($arg)*)
         ).unwrap());
     }};

--- a/wasm4/src/format.rs
+++ b/wasm4/src/format.rs
@@ -13,7 +13,7 @@ macro_rules! tracef {
 
 pub use format_no_std;
 
-static mut BUF_SLICE: Option<&mut [u8]> = None;
+pub static mut BUF_SLICE: Option<&mut [u8]> = None;
 
 pub struct Log;
 impl Log {

--- a/wasm4/src/lib.rs
+++ b/wasm4/src/lib.rs
@@ -19,6 +19,9 @@ mod utils;
 pub use self::utils::OutOfDomainError;
 pub use wasm4_sys as sys;
 
+#[cfg(feature = "tracef")]
+pub mod format;
+
 pub fn trace(msg: &str) {
     unsafe { sys::traceUtf8(msg.as_ptr(), msg.len()) }
 }

--- a/wasm4/src/lib.rs
+++ b/wasm4/src/lib.rs
@@ -13,6 +13,7 @@ pub mod __private;
 pub mod draw;
 pub mod rt;
 pub mod sound;
+pub mod control;
 mod utils;
 
 pub use self::utils::OutOfDomainError;

--- a/wasm4/src/rt.rs
+++ b/wasm4/src/rt.rs
@@ -21,7 +21,12 @@ impl Resources {
             framebuffer: crate::draw::Framebuffer::new_(),
             controls: crate::control::Controls {
                 mouse: crate::control::Mouse::new_(),
-                gamepad: crate::control::Gamepad::new_(),
+                gamepads: [
+                    crate::control::Gamepad::new_(wasm4_sys::GAMEPAD1),
+                    crate::control::Gamepad::new_(wasm4_sys::GAMEPAD2),
+                    crate::control::Gamepad::new_(wasm4_sys::GAMEPAD3),
+                    crate::control::Gamepad::new_(wasm4_sys::GAMEPAD4),
+                ],
             }
         }
     }

--- a/wasm4/src/rt.rs
+++ b/wasm4/src/rt.rs
@@ -8,6 +8,7 @@ pub trait Runtime {
 pub struct Resources {
     pub sound: crate::sound::Audio,
     pub framebuffer: crate::draw::Framebuffer,
+    pub controls: crate::control::Controls,
 }
 
 #[doc(hidden)]
@@ -18,6 +19,10 @@ impl Resources {
         Resources {
             sound: crate::sound::Audio(()),
             framebuffer: crate::draw::Framebuffer::new_(),
+            controls: crate::control::Controls {
+                mouse: crate::control::Mouse::new_(),
+                gamepad: crate::control::Gamepad::new_(),
+            }
         }
     }
 }

--- a/wasm4/src/rt.rs
+++ b/wasm4/src/rt.rs
@@ -9,6 +9,8 @@ pub struct Resources {
     pub sound: crate::sound::Audio,
     pub framebuffer: crate::draw::Framebuffer,
     pub controls: crate::control::Controls,
+    #[cfg(feature = "tracef")]
+    pub logger: crate::format::Log,
 }
 
 #[doc(hidden)]
@@ -27,7 +29,9 @@ impl Resources {
                     crate::control::Gamepad::new_(wasm4_sys::GAMEPAD3),
                     crate::control::Gamepad::new_(wasm4_sys::GAMEPAD4),
                 ],
-            }
+            },
+            #[cfg(feature = "tracef")]
+            logger: crate::format::Log::new_(),
         }
     }
 }


### PR DESCRIPTION
Found your crate, liked how it looked and decided to use it for my project before realizing it's a little bit unfinished. So I just added some of the essentials.

For mouse and controllers I decided to put them in as resources and mimic the way Framebuffer has been implemented.

I decided to put tracef!() behind a feature flag for now, because it uses `format_no_std` crate as a dependency.